### PR TITLE
Remove Google Analytics to make md2pdf compliant with GDPR (2nd try)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,21 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=UA-113872741-7"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-
-      gtag('config', 'UA-113872741-7');
-    </script>
-
     <!--For Facebook-->
     <meta name="og:image" content="%PUBLIC_URL%/static/og-img.jpg" />
     <meta name="og:title" content="md2pdf - Markdown to PDF" />


### PR DESCRIPTION
Second try, first PR seemingly vanished. As per [realdennis' suggestion](https://github.com/realdennis/md2pdf/issues/38#issuecomment-865011246).